### PR TITLE
Fix Cleanup

### DIFF
--- a/regsb.sh
+++ b/regsb.sh
@@ -65,7 +65,7 @@ do
 
 				while read -r directory
 				do
-					rm -rfv "$directory"
+					rm -rfv ~/Desktop/"$directory"
 				done < ~/Desktop/cleanuptemp.txt
 
 				rm -rfv ~/Desktop/cleanuptemp.txt


### PR DESCRIPTION
I broke cleanup by referring to the directory name alone with no
further context; this fixes it
